### PR TITLE
remove branch referenced by  shared crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 rustafarian-project = { git = "https://github.com/Rustafarian-Unitn/rustafarian-project/", branch = "project-fair" }
 rand = { version = "0.8" }
-rustafarian-shared = { git = "https://github.com/Rustafarian-Unitn/rustafarian-shared", branch = "main" }
+rustafarian-shared = { git = "https://github.com/Rustafarian-Unitn/rustafarian-shared" }
 


### PR DESCRIPTION
Differences in branch referenced by the Cargo.toml generate compiler problems. It is best to reference the default branch unless there is a specific reason not to do it.
